### PR TITLE
Find Gaussian executable properly

### DIFF
--- a/PoltypeModules/poltype.py
+++ b/PoltypeModules/poltype.py
@@ -41,7 +41,7 @@ from rdkit.Chem import rdmolfiles,AllChem,rdmolops
 from rdkit.Geometry import Point3D
 class PolarizableTyper():
 
-    def __init__(self,scfmaxiter=300,suppresstorfiterr=False,obminimizeexe='obminimize',readinionly=False,suppressdipoleerr=False,topologylib='residue_connect.txt',poltypepath=os.path.split(__file__)[0],WBOtol=.001,dontfrag=False,isfragjob=False,dipoletol=.1,externalapi=None,printoutput=False,poltypeini=True,structure=None,prmstartidx=401,numproc=1,maxmem="700MB",maxdisk="100GB",gausdir=None,gdmadir=None,tinkerdir=None,scratchdir="/scratch",paramhead=os.path.abspath(os.path.join(os.path.split(__file__)[0] , os.pardir))+ "/amoebabio18_header.prm",babelexe="babel",gausexe='g09',formchkexe='formchk',cubegenexe='cubegen',gdmaexe='gdma',avgmpolesexe=os.path.abspath(os.path.join(os.path.abspath(os.path.join(__file__, os.pardir)), os.pardir)) + "/avgmpoles.pl",peditexe='poledit',potentialexe='potential',minimizeexe='minimize',analyzeexe='analyze',superposeexe='superpose',defopbendval=0.20016677990819662,Hartree2kcal_mol=627.5095,optbasisset='6-31G*',toroptbasisset='6-31G*',dmabasisset='6-311G**',espbasisset="6-311++G(2d,2p)",torspbasisset="6-311+G*",optmethod='wB97X-D',toroptmethod='wB97X-D',torspmethod='MP2',dmamethod='MP2',espmethod='MP2',qmonly = False,espfit = True,parmtors = True,foldnum=3,foldoffsetlist = [ 0.0, 180.0, 0.0, 0.0, 0.0, 0.0 ],torlist = None,rotbndlist = None,fitrotbndslist=None,maxRMSD=.1,maxRMSPD=1,maxtorRMSPD=1.8,tordatapointsnum=None,gentorsion=False,gaustorerror=False,torsionrestraint=.1,onlyrotbndslist=None,rotalltors=False,dontdotor=False,dontdotorfit=False,toroptpcm=False,optpcm=False,torsppcm=False,use_gaus=False,use_gausoptonly=False,freq=False,postfit=False,bashrcpath=None,amoebabioprmpath=None,libpath=os.path.abspath(os.path.join(os.path.split(__file__)[0] , os.pardir))+ "/lib.bio18_conv1.txt",SMARTSToTypelibpath=sys.path[0]+'/SMARTSToTypeLib.txt',ModifiedResiduePrmPath=sys.path[0]+'/ModifiedResidue.prm',modifiedproteinpdbname=None,unmodifiedproteinpdbname=None,mutatedsidechain=None,mutatedresiduenumber=None,modifiedresiduepdbcode=None,optmaxcycle=5,torkeyfname=None,gausoptcoords='',helpfile='README_HELP.MD',versionfile='README_VERSION.MD'): 
+    def __init__(self,scfmaxiter=300,suppresstorfiterr=False,obminimizeexe='obminimize',readinionly=False,suppressdipoleerr=False,topologylib='residue_connect.txt',poltypepath=os.path.split(__file__)[0],WBOtol=.001,dontfrag=False,isfragjob=False,dipoletol=.1,externalapi=None,printoutput=False,poltypeini=True,structure=None,prmstartidx=401,numproc=1,maxmem="700MB",maxdisk="100GB",gausdir=None,gdmadir=None,tinkerdir=None,scratchdir="/scratch",paramhead=os.path.abspath(os.path.join(os.path.split(__file__)[0] , os.pardir))+ "/amoebabio18_header.prm",babelexe="babel",gausexe=None,formchkexe='formchk',cubegenexe='cubegen',gdmaexe='gdma',avgmpolesexe=os.path.abspath(os.path.join(os.path.abspath(os.path.join(__file__, os.pardir)), os.pardir)) + "/avgmpoles.pl",peditexe='poledit',potentialexe='potential',minimizeexe='minimize',analyzeexe='analyze',superposeexe='superpose',defopbendval=0.20016677990819662,Hartree2kcal_mol=627.5095,optbasisset='6-31G*',toroptbasisset='6-31G*',dmabasisset='6-311G**',espbasisset="6-311++G(2d,2p)",torspbasisset="6-311+G*",optmethod='wB97X-D',toroptmethod='wB97X-D',torspmethod='MP2',dmamethod='MP2',espmethod='MP2',qmonly = False,espfit = True,parmtors = True,foldnum=3,foldoffsetlist = [ 0.0, 180.0, 0.0, 0.0, 0.0, 0.0 ],torlist = None,rotbndlist = None,fitrotbndslist=None,maxRMSD=.1,maxRMSPD=1,maxtorRMSPD=1.8,tordatapointsnum=None,gentorsion=False,gaustorerror=False,torsionrestraint=.1,onlyrotbndslist=None,rotalltors=False,dontdotor=False,dontdotorfit=False,toroptpcm=False,optpcm=False,torsppcm=False,use_gaus=False,use_gausoptonly=False,freq=False,postfit=False,bashrcpath=None,amoebabioprmpath=None,libpath=os.path.abspath(os.path.join(os.path.split(__file__)[0] , os.pardir))+ "/lib.bio18_conv1.txt",SMARTSToTypelibpath=sys.path[0]+'/SMARTSToTypeLib.txt',ModifiedResiduePrmPath=sys.path[0]+'/ModifiedResidue.prm',modifiedproteinpdbname=None,unmodifiedproteinpdbname=None,mutatedsidechain=None,mutatedresiduenumber=None,modifiedresiduepdbcode=None,optmaxcycle=5,torkeyfname=None,gausoptcoords='',helpfile='README_HELP.MD',versionfile='README_VERSION.MD'): 
         self.scfmaxiter=scfmaxiter
         self.suppresstorfiterr=suppresstorfiterr
         self.obminimizeexe=obminimizeexe
@@ -468,24 +468,26 @@ class PolarizableTyper():
         Description: -
         """
         if self.use_gaus:
-            if (self.gausdir is not None):
-                if self.which(os.path.join(self.gausdir,"g09")) is not None:
-                    self.gausexe    = os.path.join(self.gausdir,"g09")
-                    self.formchkexe = os.path.join(self.gausdir,self.formchkexe)
-                    self.cubegenexe = os.path.join(self.gausdir,self.cubegenexe)
-                elif self.which(os.path.join(self.gausdir,"g03")) is not None:
-                    self.gausexe    = os.path.join(self.gausdir,"g03")
-                    self.formchkexe = os.path.join(self.gausdir,self.formchkexe)
-                    self.cubegenexe = os.path.join(self.gausdir,self.cubegenexe)
-                else:
-                    print("ERROR: Invalid Gaussian directory: ", self.gausdir)
-                    sys.exit(1)
-    
+            if self.gausdir is None:
+                self.gausdir = ""
+            if self.gausexe is None:
+                self.gausexe = ""
+            if self.which(os.path.join(self.gausdir, self.gausexe)) is None:
+                for g in ["g16", "g09", "g03"]:
+                    gausexe = self.which(os.path.join(self.gausdir, g))
+                    if gausexe is not None:
+                        self.gausexe = gausexe
+                        self.gausdir = os.path.dirname(gausexe)
+                        break
+            if self.which(os.path.join(self.gausdir, self.gausexe)) is None:
+                print("ERROR: Invalid Gaussian directory: ", self.gausdir)
+                sys.exit(1)
+            self.cubegenexe = os.path.join(self.gausdir,self.cubegenexe)
+            self.formchkexe = os.path.join(self.gausdir,self.formchkexe)
+
         if self.which('obminimize') is not None:
             self.obminimizeexe = self.which('obminimize')
 
-                
-    
         cmdstr=self.analyzeexe+' '+os.path.abspath(os.path.join(self.poltypepath, os.pardir))+r'/'+'water.xyz'+' '+'-k'+' '+os.path.abspath(os.path.join(self.poltypepath, os.pardir))+r'/'+'water.key'+' '+'e'+'>'+' '+'version.out'
         try:
             print('Calling: '+cmdstr) 
@@ -1068,3 +1070,4 @@ class PolarizableTyper():
 if __name__ == '__main__':
     poltype=PolarizableTyper() 
     params=poltype.main()
+                                                                                                   


### PR DESCRIPTION
This is a more robust method of finding the Gaussian executable (and its directory). I have included `g16`, since `g09` and `g03` are relatively outdated, with preference to newer versions, if multiple are installed. (For instance, my cluster has deprecated `g09` recently.)