### PR TITLE
Improve GrabBoolValue

### DIFF
--- a/PoltypeModules/poltype.py
+++ b/PoltypeModules/poltype.py
@@ -422,12 +422,12 @@ class PolarizableTyper():
         if not __name__ == '__main__':
             params=self.main()
 
-    def GrabBoolValue(self,value): 
-        if value=='true' or value=='True' or value=='TRUE':
-            boolvalue=True
-        elif value=='false' or value=='False' or value=='FALSE':
-            boolvalue=False
-        return boolvalue
+    def GrabBoolValue(self, value):
+        if value.lower() == 'true':
+            return True
+        if value.lower() == 'false':
+            return False
+        raise ValueError('Could not convert "{}" into a boolean!'.format(value))
 
     def SanitizeQMMethod(self,method,optmethodbool):
         if method[-1]=='D': # assume DFT, gaussian likes D, PSI4 likes -D


### PR DESCRIPTION
I ran across an issue when I had misspelled "false" in my input file, which raised `UnboundLocalError: local variable 'boolvalue' referenced before assignment`. Since a misspelling of "true" or "false" (or any other string!) would not set `boolvalue`, it would raise this error.

This should be able to handle all cases from before ("true", "True", "TRUE"), as well as more esoteric capitalization ("TRue", "tRuE", etc.) [and similarly for false strings].