### PR TITLE
Generate final key and xyz files for single atom calls

### DIFF
--- a/PoltypeModules/optimization.py
+++ b/PoltypeModules/optimization.py
@@ -322,16 +322,19 @@ def CheckRMSD(poltype):
                 raise ValueError(os.getcwd()+' '+'RMSD of QM and MM optimized structures is high, RMSD = '+str(RMSD))
 
 def StructureMinimization(poltype):
-     poltype.WriteToLog("")
-     poltype.WriteToLog("=========================================================")
-     poltype.WriteToLog("Minimizing structure\n")
-    
-     cmd='cp ' + poltype.xyzoutfile + ' ' + poltype.tmpxyzfile
-     poltype.call_subsystem(cmd)
-     cmd='cp ' + poltype.key5fname + ' ' + poltype.tmpkeyfile
-     poltype.call_subsystem(cmd)
-     cmd = poltype.minimizeexe+' -k '+poltype.tmpkeyfile+' '+poltype.tmpxyzfile+' 0.1 > Minimizedttt.out'
-     poltype.call_subsystem(cmd,True)
+    poltype.WriteToLog("")
+    poltype.WriteToLog("=========================================================")
+    poltype.WriteToLog("Minimizing structure\n")
+
+    cmd='cp ' + poltype.xyzoutfile + ' ' + poltype.tmpxyzfile
+    poltype.call_subsystem(cmd)
+
+    cmd='cp ' + poltype.key5fname + ' ' + poltype.tmpkeyfile
+    poltype.call_subsystem(cmd)
+
+    if poltype.numatom != 1:
+        cmd = poltype.minimizeexe+' -k '+poltype.tmpkeyfile+' '+poltype.tmpxyzfile+' 0.1 > Minimized_final.out'
+        poltype.call_subsystem(cmd, True)
 
 
 def GeometryOptimization(poltype,mol):

--- a/PoltypeModules/poltype.py
+++ b/PoltypeModules/poltype.py
@@ -1305,9 +1305,8 @@ class PolarizableTyper():
         self.WriteOutLiteratureReferences(self.key5fname) 
         # A series of tests are done so you one can see whether or not the parameterization values
         # found are acceptable and to what degree
-        if self.atomnum!=1: 
-
-            opt.StructureMinimization(self)
+        opt.StructureMinimization(self)
+        if self.atomnum != 1:
             opt.gen_superposeinfile(self)
             opt.CheckRMSD(self)
         if self.torsppcm:


### PR DESCRIPTION
The main difference here is calling `opt.StructureMinimization()` on single atoms, which essentially just copies the requisite files to final.{key,xyz} to ensure the used has "final" parameters. I also renamed Minimizedttt.out to Minimized_final.out, since it no longer outputs ttt.{key,xyz}.

[This is mainly cosmetic, but ensures the user will always get the "final" outputs.]