### PR TITLE
Get ParmEd from Conda-Forge instead of GitHub

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -11,8 +11,7 @@ dependencies:
   - cairosvg
   - mdanalysis
   - openbabel=2.4.1
+  - parmed
   - svgutils
   - psi4
   - rdkit
-  - pip:
-    - git+git://github.com/ParmEd/ParmEd.git


### PR DESCRIPTION
Parmed v3.4.0 is available through conda-forge and is recent enough to have the requisite changes that poltype required