### PR TITLE
Equations added (tried to) in the torsion documentation

### DIFF
--- a/README_TORSIONFIT.MD
+++ b/README_TORSIONFIT.MD
@@ -9,9 +9,8 @@ Additionally, torsion rotations are categorized by symmetry, based on the atoms 
 
 To proceed with the fitting, first QM and MM energies are **normalized**, and the QM value is then subtracted from the MM one. If a second try for the fitting procedure is required, the Boltzmann weight defined as
 
-```math
- e^{-E_{QM}/8}.
-```
+![ e^{-E_{QM}/8}.](https://render.githubusercontent.com/render/math?math=%5Cdisplaystyle++e%5E%7B-E_%7BQM%7D%2F8%7D.)
+
 
 From all the QM - MM energies differences a min/max criterion is used to set the boundaries to evaluate the fitting quality. Those boundaries are identified by the amplitude between the max and min. The parameters for fitting are then initialized, for each fold of the torsion potential energy term. In addition to the min/max boundaries, also boundaries for the phase angle (0-2$\pi$) for fitting phase angle and also an additional criterion is defined for non-aromatic ring puckering torsion parameters.
 

--- a/README_TORSIONGENERATOR.MD
+++ b/README_TORSIONGENERATOR.MD
@@ -1,9 +1,9 @@
 ## Torsion README
 
-```math
-\mathcal{E}_{\rm{torsion}} = \sum_{n} K_{n\phi} [1 + cos(n\phi \pm \delta)]
-```
-​
+![\mathcal{E}_{\rm{torsion}} = \sum_{n} K_{n\phi} [1 + cos(n\phi \pm \delta)]
+
+](https://render.githubusercontent.com/render/math?math=%5Cdisplaystyle+%5Cmathcal%7BE%7D_%7B%5Crm%7Btorsion%7D%7D+%3D+%5Csum_%7Bn%7D+K_%7Bn%5Cphi%7D+%5B1+%2B+cos%28n%5Cphi+%5Cpm+%5Cdelta%29%5D%0A%0A)
+
 
 First the torsion angles are identified in the actual molecular structure through the **torsiongenerator.py** program; a QM relaxed scan with constraints, is then performed for each of the dihedrals identified (or a selected subset of the molecular dihedrals), in order to derive the force field dihedral parameter, fitting the classical torsion energy functional (which is a parametric functional) as defined in the AMOEBA force field to those QM data. This crucial part of the procedure is executed by a second program, namely **torsionfit.py**.
 


### PR DESCRIPTION
I tried a syntax for equations which I found in the github forum, translating standard latex with this application:

https://tex-image-link-generator.herokuapp.com/